### PR TITLE
Allow sending config params to the base class initializer

### DIFF
--- a/lib/hasoffers/base.rb
+++ b/lib/hasoffers/base.rb
@@ -13,19 +13,15 @@ module HasOffers
         @@base_uri
       end
 
-      def initialize_credentials
+      def initialize_credentials(config={})
         config_file = ENV['HAS_OFFERS_CONFIG_FILE'] || "config/has_offers.yml"
-        if File.exists?(config_file)
-          config = YAML::load(IO.read(config_file))
-          @@default_params = {'Format' => 'json',
-                              'Service' => 'HasOffers',
-                              'Version' => '2',
-                              'NetworkId' => config['network_id'],
-                              'NetworkToken' => config['api_key']}
-        else
-          @@default_params = {}
-          puts "Missing config/has_offers.yml file!"
-        end
+        config.merge!YAML::load(IO.read(config_file)) if File.exists?(config_file)
+
+        @@default_params = {'Format' => 'json',
+                            'Service' => 'HasOffers',
+                            'Version' => '2',
+                            'NetworkId' => config['network_id'],
+                            'NetworkToken' => config['api_key']}
       end
 
       def test?


### PR DESCRIPTION
If we use config/has_offiers.yml we should expose our keys in the repo. Using ENV vars is a good practice and this will allow adding:
'HasOffers::Base.initialize_credentials({network_id: ENV['HASOFFERS_NETWORK'], api_key: ENV['HASOFFERS_KEY']})'
in the initializers folder and set the proper config for the app.
